### PR TITLE
fix(customer): enable interactive address creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ super-linter.log
 /*.sql.gz
 
 .tokensave
+.serena
 
 # Claude Code
 .claude/.headroom_wrap_marker.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,28 @@ RECENT CHANGES
 10.0.0-dev (2026-07-05)
 ------------------------
 
+- Break: raise minimum PHP requirement to 8.2 (and update laminas dependencies accordingly)
 - Add: interactive download command for Magento/Adobe Commerce/Mage-OS
+- Add: prompt interactively for `integration:create` arguments and make `integration:delete` interactive when no name is given
+- Imp: overhaul command output look and feel
+- Fix: stop double-JSON-encoding `admin_user.extra` on `admin:user:change-status`
+- Fix: surface mysql errors and reject silent empty queries in `db:query`
+- Fix: MCP proxy commands returning a generic `bin/magento` list
+- Fix: build MCP command input from ArrayInput to preserve arguments verbatim
+- Fix: resolve installer plugin package by class instead of name
+- Fix: build a Magento-scoped Composer instance and resolve the real plugin package for the allow-plugins check in `composer:redeploy-base-packages`
+- Fix: remove broken `pv` branch in non-piped decompression commands
+- Fix: guard against undefined STDIN constant in prompt fallback check, and fall back to the first option in `select()` when non-interactive
 - Test: add unit tests for the download command
+- Test: add regression test for `admin:user:change-status` extra column
+- Test: use the real DatabaseHelper in `QueryCommandTest` CSV test
+- Test: make functional bats tests idempotent
 - Security: gate `pull_request_target` CI behind maintainer approval
 - Fix: switch platform tests from Mage-OS 3.0.0 to 3.1.0
 - Chore: ignore tarballs
 - Docs: fix composer require command in README
-- Build: update dependencies (actions/cache, actions/checkout, super-linter, php-cs-fixer, phpstan, psy/psysh, twig/twig, mcp/sdk, npm/yarn group)
+- Docs: update db-dump documentation
+- Build: update dependencies (actions/cache, actions/checkout, actions/setup-node, super-linter, php-cs-fixer, phpstan, psy/psysh, twig/twig, mcp/sdk, rmccue/requests, js-yaml, postcss, websocket-driver, npm/yarn group)
 
 9.5.1 (2026-05-21)
 ------------------

--- a/docs/docs/command-docs/cache/cache-disable.md
+++ b/docs/docs/command-docs/cache/cache-disable.md
@@ -14,6 +14,6 @@ n98-magerun2.phar cache:disable [--format[=FORMAT]] [type...]
 
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 If no code is specified, all cache types will be disabled. Run `cache:list` command to see all codes.

--- a/docs/docs/command-docs/cache/cache-enable.md
+++ b/docs/docs/command-docs/cache/cache-enable.md
@@ -14,6 +14,6 @@ n98-magerun2.phar cache:enable [--format[=FORMAT]] [type...]
 
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 If no code is specified, all cache types will be enabled. Run `cache:list` command to see all codes.

--- a/docs/docs/command-docs/cache/cache-list.md
+++ b/docs/docs/command-docs/cache/cache-list.md
@@ -15,4 +15,4 @@ n98-magerun2.phar cache:list [--enabled[=ENABLED]] [--format[=FORMAT]]
 | Option                | Description                                                              |
 |-----------------------|--------------------------------------------------------------------------|
 | `--enabled[=ENABLED]` | Filter the list to display only enabled [1] or disabled [0] cache types  |
-| `--format[=FORMAT]`   | Output Format. One of [csv,json,json_array,yaml,xml]                     |
+| `--format[=FORMAT]`   | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                     |

--- a/docs/docs/command-docs/cache/cache-report.md
+++ b/docs/docs/command-docs/cache/cache-report.md
@@ -21,4 +21,4 @@ n98-magerun2.phar cache:report [options]
 | `-m, --mtime`               | Output last modification time                                  |
 | `--filter-id[=FILTER-ID]`   | Filter output by ID (substring)                                |
 | `--filter-tag[=FILTER-TAG]` | Filter output by TAG (separate multiple tags by comma)         |
-| `--format[=FORMAT]`         | Output Format. One of [csv, json, json_array, yaml, xml]       |
+| `--format[=FORMAT]`         | Output Format. One of [csv, tsv, json, json_array, jsonl, yaml, markdown, xml]. Aliases: yml, md, ndjson       |

--- a/docs/docs/command-docs/config/config-data-indexer.md
+++ b/docs/docs/command-docs/config/config-data-indexer.md
@@ -16,7 +16,7 @@ n98-magerun2.phar config:data:indexer [options]
 |---------------------|---------------------------------------------------------------------------------------------------------|
 | `--scope` `-s`      | Config scope (`global`, `adminhtml`, `frontend`, `webapi_rest`, `webapi_soap`, ...) (default: `global`) |
 | `--tree` `-t`       | Print data as tree                                                                                      |
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml]                                                    |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                                                    |
 
 
 ---

--- a/docs/docs/command-docs/config/config-data-mview.md
+++ b/docs/docs/command-docs/config/config-data-mview.md
@@ -16,7 +16,7 @@ n98-magerun2.phar config:data:mview [options]
 |---------------------|---------------------------------------------------------------------------------------------------------|
 | `--scope` `-s`      | Config scope (`global`, `adminhtml`, `frontend`, `webapi_rest`, `webapi_soap`, ...) (default: `global`) |
 | `--tree` `-t`       | Print data as tree                                                                                      |
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml]                                                    |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                                                    |
 
 
 ---

--- a/docs/docs/command-docs/config/config-store-get.md
+++ b/docs/docs/command-docs/config/config-store-get.md
@@ -25,7 +25,7 @@ n98-magerun2.phar config:store:get [--scope="..."] [--scope-id="..."] [--decrypt
 | `--decrypt`        | Decrypt the config value using crypt key defined in `env.php`.               |
 | `--update-script`  | Output as update script lines.                                               |
 | `--magerun-script` | Output for usage with `config:store:set`.                                    |
-| `--format[=FORMAT]`| Output Format. One of [csv,json,json_array,yaml,xml].                        |
+| `--format[=FORMAT]`| Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |
 
 **Help:**
 
@@ -36,4 +36,3 @@ If path is not set, all available config items will be listed. path may contain 
 ```sh
 n98-magerun2.phar config:store:get web/* --magerun-script
 ```
-

--- a/docs/docs/command-docs/customer/customer-create.md
+++ b/docs/docs/command-docs/customer/customer-create.md
@@ -25,7 +25,7 @@ n98-magerun2.phar customer:create foo@example.com passworD123 John Doe base taxv
 
 | Option              | Description                                          |
 |---------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 ---
 

--- a/docs/docs/command-docs/db/db-info.md
+++ b/docs/docs/command-docs/db/db-info.md
@@ -25,7 +25,7 @@ n98-magerun2.phar db:info [options] [--] [<setting>]
 | Option                   | Description                                                                 |
 |--------------------------|-----------------------------------------------------------------------------|
 | `--connection=CONNECTION`| Select DB connection type for Magento configurations with several databases |
-| `--format[=FORMAT]`      | Output Format. One of [csv,json,json_array,yaml,xml]                        |
+| `--format[=FORMAT]`      | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |
 
 **Help:**
 

--- a/docs/docs/command-docs/db/db-maintain-check-tables.md
+++ b/docs/docs/command-docs/db/db-maintain-check-tables.md
@@ -21,4 +21,4 @@ n98-magerun2.phar db:maintain:check-tables [options]
 | `--type[=TYPE]`    | Check type (one of QUICK, FAST, MEDIUM, EXTENDED, CHANGED) [default: "MEDIUM"] |
 | `--repair`         | Repair tables (only MyISAM)                                                 |
 | `--table[=TABLE]`  | Process only given table (wildcards are supported)                          |
-| `--format[=FORMAT]`| Output Format. One of [csv,json,json_array,yaml,xml]                        |
+| `--format[=FORMAT]`| Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |

--- a/docs/docs/command-docs/db/db-status.md
+++ b/docs/docs/command-docs/db/db-status.md
@@ -25,6 +25,6 @@ n98-magerun2.phar db:status [options] [--] [<search>]
 | Option                   | Description                                                                 |
 |--------------------------|-----------------------------------------------------------------------------|
 | `--connection=CONNECTION`| Select DB connection type for Magento configurations with several databases |
-| `--format[=FORMAT]`      | Output Format. One of [csv,json,json_array,yaml,xml]                        |
+| `--format[=FORMAT]`      | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |
 | `--rounding[=ROUNDING]`  | Amount of decimals to display. If -1 then disabled [default: 0]             |
 | `--no-description`       | Disable description                                                         |

--- a/docs/docs/command-docs/db/db-variables.md
+++ b/docs/docs/command-docs/db/db-variables.md
@@ -25,6 +25,6 @@ n98-magerun2.phar db:variables [options] [--] [<search>]
 | Option                   | Description                                                                 |
 |--------------------------|-----------------------------------------------------------------------------|
 | `--connection=CONNECTION`| Select DB connection type for Magento configurations with several databases |
-| `--format[=FORMAT]`      | Output Format. One of [csv,json,json_array,yaml,xml]                        |
+| `--format[=FORMAT]`      | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |
 | `--rounding[=ROUNDING]`  | Amount of decimals to display. If -1 then disabled [default: 0]             |
 | `--no-description`       | Disable description                                                         |

--- a/docs/docs/command-docs/development/dev-module-list.md
+++ b/docs/docs/command-docs/development/dev-module-list.md
@@ -11,7 +11,7 @@ n98-magerun2.phar dev:module:list [options]
 | `--vendor[=VENDOR]` | Show modules of a specific vendor (case insensitive)   |
 | `-e, --only-enabled`| Show only enabled modules                              |
 | `-d, --only-disabled`| Show only disabled modules                             |
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml]   |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson   |
 
 :::info
 Lists all installed modules. You can filter by vendor, enabled/disabled state, and output format. Useful for auditing and debugging module status.

--- a/docs/docs/command-docs/development/dev-module-observer-list.md
+++ b/docs/docs/command-docs/development/dev-module-observer-list.md
@@ -24,4 +24,4 @@ n98-magerun2.phar dev:module:observer:list [--sort] [--format=FORMAT] [<event> [
 | Option            | Description                                         |
 |-------------------|-----------------------------------------------------|
 | --sort            | Sort output ascending by event name                 |
-| --format=FORMAT   | Output Format. One of [csv,json,json_array,yaml,xml]|
+| --format=FORMAT   | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson|

--- a/docs/docs/command-docs/development/dev-theme-list.md
+++ b/docs/docs/command-docs/development/dev-theme-list.md
@@ -8,7 +8,7 @@ n98-magerun2.phar dev:theme:list [--format[=FORMAT]]
 **Options:**
 | Option             | Description                                          |
 |--------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 :::info
 Lists all available Magento themes. You can change the output format for easier integration with other tools or scripts.

--- a/docs/docs/command-docs/eav/eav-attribute-list.md
+++ b/docs/docs/command-docs/eav/eav-attribute-list.md
@@ -22,4 +22,4 @@ n98-magerun2.phar eav:attribute:list [options]
 | `--add-source`             | Add source models to list.                           |
 | `--add-backend`            | Add backend type to list.                            |
 | `--filter-type[=FILTER-TYPE]` | Filter attributes by entity type.                    |
-| `--format[=FORMAT]`        | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]`        | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/eav/eav-attribute-view.md
+++ b/docs/docs/command-docs/eav/eav-attribute-view.md
@@ -24,4 +24,4 @@ n98-magerun2.phar eav:attribute:view [--format[="..."]] <entityType> <attributeC
 **Options:**
 | Option             | Description                                          |
 |--------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/index/index-list.md
+++ b/docs/docs/command-docs/index/index-list.md
@@ -18,4 +18,4 @@ n98-magerun2.phar index:list [--format[=FORMAT]]
 ## Options
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/integration/integration-create.md
+++ b/docs/docs/command-docs/integration/integration-create.md
@@ -28,7 +28,7 @@ n98-magerun2.phar integration:create [options] [--] <name> [<email> [<endpoint>]
 | `--access-token=ACCESS-TOKEN`               | Access-Token (length 32 chars)                           |
 | `--access-token-secret=ACCESS-TOKEN-SECRET` | Access-Token Secret (length 32 chars)                    |
 | `--resource=RESOURCE` `-r`                  | Defines a granted ACL resource (multiple values allowed) |
-| `--format[=FORMAT]`                         | Output Format. One of [csv,json,json_array,yaml,xml]     |
+| `--format[=FORMAT]`                         | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson     |
 
 :::warning
 If no ACL resource is defined, the new integration token will be created with FULL ACCESS. To restrict access, provide a list of ACL resources using the `--resource` option.

--- a/docs/docs/command-docs/integration/integration-list.md
+++ b/docs/docs/command-docs/integration/integration-list.md
@@ -16,4 +16,4 @@ n98-magerun2.phar integration:list [--format[=FORMAT]]
 **Options:**
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/integration/integration-show.md
+++ b/docs/docs/command-docs/integration/integration-show.md
@@ -24,7 +24,7 @@ n98-magerun2.phar integration:show [--format[=FORMAT]] <name_or_id> [<key>]
 **Options:**
 | Option             | Description                                          |
 |--------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 ## Example (print only Access Key)
 ```sh

--- a/docs/docs/command-docs/routes/route-list.md
+++ b/docs/docs/command-docs/routes/route-list.md
@@ -13,7 +13,7 @@ n98-magerun2.phar route:list [-a|--area=AREA] [-m|--module=MODULE] [--format=FOR
 |--------------------------|------------------------------------------------------|
 | `-a, --area[=AREA]`      | Route area code. One of [frontend,adminhtml]         |
 | `-m, --module[=MODULE]`  | Show registered routes of a module                   |
-| `--format[=FORMAT]`      | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]`      | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 
 ---

--- a/docs/docs/command-docs/search/search-engine-list.md
+++ b/docs/docs/command-docs/search/search-engine-list.md
@@ -17,4 +17,4 @@ n98-magerun2.phar search:engine:list [--format[=FORMAT]]
 
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/system/sys-cron-history.md
+++ b/docs/docs/command-docs/system/sys-cron-history.md
@@ -18,4 +18,4 @@ n98-magerun2.phar sys:cron:history [--format[="..."]] [--timezone[="..."]]
 | Option                | Description                                          |
 |-----------------------|------------------------------------------------------|
 | `--timezone[=TIMEZONE]`| Timezone to show finished at in                      |
-| `--format[=FORMAT]`   | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]`   | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/system/sys-cron-list.md
+++ b/docs/docs/command-docs/system/sys-cron-list.md
@@ -21,7 +21,7 @@ n98-magerun2.phar sys:cron:list [<job_code>] [--format[="..."]]
 ## Options
 | Option              | Description                                          |
 |---------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 The `--format` option allows you to specify the output format for the list of cronjobs. Supported formats are:
 - csv

--- a/docs/docs/command-docs/system/sys-setup-compare-versions.md
+++ b/docs/docs/command-docs/system/sys-setup-compare-versions.md
@@ -14,7 +14,6 @@ n98-magerun2.phar sys:setup:compare-versions [--ignore-data] [--log-junit="..."]
 |------------------------|------------------------------------------------------|
 | `--ignore-data`        | Ignore data updates                                  |
 | `--log-junit=LOG-JUNIT`| Log output to a JUnit xml file.                      |
-| `--format[=FORMAT]`    | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]`    | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 - If a filename with `--log-junit` option is set the tool generates an XML file and no output to *stdout*.
-

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -3,3 +3,4 @@ title: Concepts
 ---
 
 - [Proxy Commands for bin/magento](./bin-magento-proxy-commands.md)
+- [Table Output Formats](./table-output-formats.md)

--- a/docs/docs/concepts/table-output-formats.md
+++ b/docs/docs/concepts/table-output-formats.md
@@ -1,0 +1,71 @@
+---
+title: Table Output Formats
+sidebar_label: Table Output Formats
+---
+
+# Table Output Formats
+
+Commands that display tabular data provide a shared `--format` option. The option is available on commands such as `cache:list`, `customer:list`, `index:list`, and `sys:cron:list`.
+
+## Supported Formats
+
+| Format | Description |
+| --- | --- |
+| `csv` | Comma-separated values with a header row. Suitable for spreadsheets and general data exchange. |
+| `tsv` | Tab-separated values with a header row. Useful when values commonly contain commas. |
+| `json` | Pretty-printed JSON object output. |
+| `json_array` | Pretty-printed JSON array output. Use this when consumers expect a JSON array rather than an object. |
+| `jsonl` | One JSON object per line. Also known as JSON Lines. Useful for streaming and shell pipelines. |
+| `yaml` | YAML output for human-readable structured data. |
+| `markdown` | Pipe-delimited Markdown table output for documentation and issue trackers. |
+| `xml` | XML output wrapped in a `<table>` element. |
+
+## Format Aliases
+
+The following aliases produce the same output as their canonical format:
+
+| Alias | Format |
+| --- | --- |
+| `yml` | `yaml` |
+| `md` | `markdown` |
+| `ndjson` | `jsonl` |
+
+Aliases are case-insensitive, as are canonical format names.
+
+## Examples
+
+Export an indexer list as CSV:
+
+```sh
+n98-magerun2.phar index:list --format=csv
+```
+
+Generate a Markdown table:
+
+```sh
+n98-magerun2.phar customer:list --format=markdown
+```
+
+Process one JSON record at a time:
+
+```sh
+n98-magerun2.phar sys:cron:list --format=jsonl | while read -r row; do
+    printf '%s\n' "$row"
+done
+```
+
+Use an alias when preferred:
+
+```sh
+n98-magerun2.phar config:search "web/*" --format=yml
+```
+
+## Invalid Formats
+
+An unsupported value does not fall back to the default terminal table. The command exits with an error that identifies the invalid format and lists the supported canonical formats.
+
+```text
+Unknown output format "toml". Supported formats: csv, tsv, json, json_array, jsonl, yaml, markdown, xml.
+```
+
+TOML and TOON are intentionally not supported output formats. TOML is primarily intended for configuration, while TOON is a specialized, less widely supported notation for token-efficient data exchange. JSON, CSV, YAML, and Markdown provide better interoperability for the command-line use cases covered by n98-magerun2.

--- a/src/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptor.php
+++ b/src/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptor.php
@@ -202,21 +202,26 @@ final class MagerunTextDescriptor extends TextDescriptor
             $isGrouped = !$describedNamespace && ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id'];
 
             if ($isGrouped) {
-                $this->writeRaw(sprintf("\n  <subheading>%s</subheading>\n", $namespace['id']), $options);
+                $this->writeRaw(sprintf(
+                    "\n  <subheading>%s</subheading>\n",
+                    OutputFormatter::escape($namespace['id'])
+                ), $options);
             }
 
             foreach ($namespace['commands'] as $name) {
                 $command = $commands[$name];
-                $aliases = $name === $command->getName() ? $this->aliasesText($command) : '';
+                $aliases = $name === $command->getName()
+                    ? OutputFormatter::escape($this->aliasesText($command))
+                    : '';
                 $indent = $isGrouped ? '    ' : '  ';
                 $padding = max(1, $width - Helper::width($name) - ($isGrouped ? 2 : 0));
 
                 $this->writeRaw(sprintf(
                     "%s<accent>%s</accent>%s<muted>%s</muted>\n",
                     $indent,
-                    $name,
+                    OutputFormatter::escape($name),
                     str_repeat(' ', $padding),
-                    $aliases . $command->getDescription()
+                    $aliases . OutputFormatter::escape($command->getDescription())
                 ), $options);
             }
         }

--- a/src/N98/Magento/Command/AbstractMagentoCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoCommand.php
@@ -124,7 +124,7 @@ abstract class AbstractMagentoCommand extends Command
             'format',
             null,
             InputOption::VALUE_OPTIONAL,
-            'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
+            'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']. Aliases: yml,md,ndjson'
         );
     }
 

--- a/src/N98/Magento/Command/Customer/AddAddressCommand.php
+++ b/src/N98/Magento/Command/Customer/AddAddressCommand.php
@@ -47,8 +47,8 @@ class AddAddressCommand extends AbstractCustomerCommand
         $this
             ->setName('customer:add-address')
             ->setDescription('Adds an address to a customer')
-            ->addArgument('email', InputArgument::REQUIRED, 'Customer email')
-            ->addArgument('website', InputArgument::REQUIRED, 'Customer website')
+            ->addArgument('email', InputArgument::OPTIONAL, 'Customer email')
+            ->addArgument('website', InputArgument::OPTIONAL, 'Customer website')
             ->addOption('firstname', null, InputOption::VALUE_REQUIRED, 'First name')
             ->addOption('lastname', null, InputOption::VALUE_REQUIRED, 'Last name')
             ->addOption('street', null, InputOption::VALUE_REQUIRED, 'Street address')
@@ -91,11 +91,7 @@ class AddAddressCommand extends AbstractCustomerCommand
 
         $isError = false;
 
-        // Email is a required argument, so we check and ask if it's not provided
-        $email = $input->getArgument('email');
-        if (!$email) {
-            $email = text('Please enter the customer\'s email: ');
-        }
+        $email = $this->getHelperSet()->get('parameter')->askEmail($input, $output);
 
         $website = $this->getHelperSet()->get('parameter')->askWebsite($input, $output);
 

--- a/src/N98/Magento/Command/Customer/DeleteCommand.php
+++ b/src/N98/Magento/Command/Customer/DeleteCommand.php
@@ -19,9 +19,10 @@ use N98\Util\Console\Helper\ParameterHelper;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-
 use Symfony\Component\Console\Input\InputOption;
+
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 /**
  * Class DeleteCommand
@@ -161,9 +162,18 @@ class DeleteCommand extends AbstractCustomerCommand
                 $isSecure = $this->registry->registry('isSecureArea');
                 $this->registry->unregister('isSecureArea');
                 $this->registry->register('isSecureArea', true);
-                $this->customerRepository->delete($customer);
-                $this->registry->unregister('isSecureArea');
-                $this->registry->register('isSecureArea', $isSecure);
+                try {
+                    $this->customerRepository->delete($customer);
+                } catch (Throwable $e) {
+                    // Some B2B modules (e.g. Magento\NegotiableQuote) fatal error on deletion
+                    // of customers whose company has no resolvable admin. Report and continue
+                    // instead of letting the whole command crash.
+                    $output->writeln(sprintf('<error>Could not delete customer: %s</error>', $e->getMessage()));
+                    return Command::FAILURE;
+                } finally {
+                    $this->registry->unregister('isSecureArea');
+                    $this->registry->register('isSecureArea', $isSecure);
+                }
             } else {
                 $output->writeln('<error>Aborting delete</error>');
             }
@@ -236,7 +246,7 @@ class DeleteCommand extends AbstractCustomerCommand
             );
 
             if ($force || $this->shouldRemove($input, $output)) {
-                $count = $this->batchDelete($customerCollection);
+                $count = $this->batchDelete($customerCollection, $output);
                 $output->writeln('<info>Successfully deleted ' . $count . ' customer/s</info>');
             } else {
                 $output->writeln('<error>Aborting delete</error>');
@@ -284,23 +294,35 @@ class DeleteCommand extends AbstractCustomerCommand
 
     /**
      * @param \Magento\Customer\Model\ResourceModel\Customer\Collection $customerCollection
+     * @param OutputInterface $output
      *
      * @return int
      * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    protected function batchDelete(Collection $customerCollection): int
+    protected function batchDelete(Collection $customerCollection, OutputInterface $output): int
     {
         $count = 0;
         $this->registry->unregister('isSecureArea');
         $this->registry->register('isSecureArea', true);
         $isSecure = $this->registry->registry('isSecureArea');
         foreach ($customerCollection as $customerToDelete) {
-            // Load the complete customer data before deleting it. This avoids Magento B2B
-            // plugins receiving the partially loaded collection entity through deleteById().
-            $customer = $this->customerRepository->getById($customerToDelete->getId());
-            if ($this->customerRepository->delete($customer)) {
-                $count++;
+            try {
+                // Load the complete customer data before deleting it. This avoids Magento B2B
+                // plugins receiving the partially loaded collection entity through deleteById().
+                $customer = $this->customerRepository->getById($customerToDelete->getId());
+                if ($this->customerRepository->delete($customer)) {
+                    $count++;
+                }
+            } catch (Throwable $e) {
+                // Some B2B modules (e.g. Magento\NegotiableQuote) fatal error on deletion of
+                // customers whose company has no resolvable admin. Report and continue with
+                // the remaining customers instead of letting the whole batch crash.
+                $output->writeln(sprintf(
+                    '<error>Could not delete customer #%s: %s</error>',
+                    $customerToDelete->getId(),
+                    $e->getMessage()
+                ));
             }
         }
         $this->registry->unregister('isSecureArea');
@@ -332,7 +354,7 @@ class DeleteCommand extends AbstractCustomerCommand
 
         // Proceed with deletion of all customers
         $customerCollection = $this->getCustomerCollection();
-        $count = $this->batchDelete($customerCollection);
+        $count = $this->batchDelete($customerCollection, $output);
         $output->writeln('<info>Successfully deleted ' . $count . ' customer/s</info>');
 
         return Command::SUCCESS;

--- a/src/N98/Magento/Command/Customer/DeleteCommand.php
+++ b/src/N98/Magento/Command/Customer/DeleteCommand.php
@@ -296,7 +296,10 @@ class DeleteCommand extends AbstractCustomerCommand
         $this->registry->register('isSecureArea', true);
         $isSecure = $this->registry->registry('isSecureArea');
         foreach ($customerCollection as $customerToDelete) {
-            if ($this->customerRepository->deleteById($customerToDelete->getId())) {
+            // Load the complete customer data before deleting it. This avoids Magento B2B
+            // plugins receiving the partially loaded collection entity through deleteById().
+            $customer = $this->customerRepository->getById($customerToDelete->getId());
+            if ($this->customerRepository->delete($customer)) {
                 $count++;
             }
         }

--- a/src/N98/Util/Console/Helper/ParameterHelper.php
+++ b/src/N98/Util/Console/Helper/ParameterHelper.php
@@ -88,7 +88,7 @@ class ParameterHelper extends AbstractHelper implements CommandAware
             }
 
             if (count($stores) > 1) {
-                $storeId = select('Please select a store', $stores);
+                $storeId = $this->selectByKey('Please select a store', $stores);
             } else {
                 // only one store view available -> take it
                 $storeId = array_key_first($stores);
@@ -138,7 +138,7 @@ class ParameterHelper extends AbstractHelper implements CommandAware
                 return $storeManager->getWebsite(array_key_first($websites));
             }
 
-            $websiteId = select('Please select a website', $websites);
+            $websiteId = $this->selectByKey('Please select a website', $websites);
 
             $website = $storeManager->getWebsite((int) $websiteId);
         }
@@ -200,6 +200,30 @@ class ParameterHelper extends AbstractHelper implements CommandAware
         );
 
         return $this->_validateArgument($argumentName, $input->getArgument($argumentName), $constraints, true);
+    }
+
+    /**
+     * Prompt a select list and return the array key of the chosen entry.
+     *
+     * Laravel Prompts' select() returns the array VALUE instead of the KEY when the
+     * given options array happens to have sequential integer keys starting at 0
+     * (e.g. store/website IDs 0, 1, 2, ...), because it is then indistinguishable
+     * from a plain list of choices. Prefixing the keys avoids that ambiguity.
+     *
+     * @param string $label
+     * @param array<int|string, string> $choices
+     * @return int|string
+     */
+    protected function selectByKey($label, array $choices)
+    {
+        $prefixedChoices = [];
+        foreach ($choices as $key => $value) {
+            $prefixedChoices['choice_' . $key] = $value;
+        }
+
+        $selected = select($label, $prefixedChoices);
+
+        return substr($selected, strlen('choice_'));
     }
 
     /**

--- a/src/N98/Util/Console/Helper/Table/Renderer/CsvRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/CsvRenderer.php
@@ -18,6 +18,8 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class CsvRenderer implements RendererInterface
 {
+    protected $delimiter = ',';
+
     /**
      * @param OutputInterface $output
      * @param array           $rows
@@ -33,9 +35,9 @@ class CsvRenderer implements RendererInterface
         $i = 0;
         foreach ($rows as $row) {
             if ($i++ == 0) {
-                fputcsv($stream, array_keys($row), escape: '"');
+                fputcsv($stream, array_keys($row), $this->delimiter, '"', escape: '"');
             }
-            fputcsv($stream, $row, escape: '"');
+            fputcsv($stream, $row, $this->delimiter, '"', escape: '"');
         }
     }
 }

--- a/src/N98/Util/Console/Helper/Table/Renderer/JsonLinesRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/JsonLinesRenderer.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * One JSON object per line renderer.
+ */
+class JsonLinesRenderer implements RendererInterface
+{
+    public function render(OutputInterface $output, array $rows)
+    {
+        foreach ($rows as $row) {
+            $output->writeln(
+                \json_encode($row, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+                OutputInterface::OUTPUT_RAW
+            );
+        }
+    }
+}

--- a/src/N98/Util/Console/Helper/Table/Renderer/MarkdownRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/MarkdownRenderer.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * GitHub-flavoured Markdown table renderer.
+ */
+class MarkdownRenderer implements RendererInterface
+{
+    public function render(OutputInterface $output, array $rows)
+    {
+        if ($rows === []) {
+            return;
+        }
+
+        $headers = array_keys($rows[0]);
+        $output->writeln($this->row($headers), OutputInterface::OUTPUT_RAW);
+        $output->writeln($this->row(array_fill(0, count($headers), '---')), OutputInterface::OUTPUT_RAW);
+
+        foreach ($rows as $row) {
+            $output->writeln($this->row(array_values($row)), OutputInterface::OUTPUT_RAW);
+        }
+    }
+
+    private function row(array $cells): string
+    {
+        $cells = array_map(fn ($cell) => $this->escape($cell), $cells);
+
+        return '| ' . implode(' | ', $cells) . ' |';
+    }
+
+    private function escape($value): string
+    {
+        return str_replace(
+            ["\\", "|", "\r\n", "\r", "\n"],
+            ["\\\\", "\\|", '<br>', '<br>', '<br>'],
+            (string) $value
+        );
+    }
+}

--- a/src/N98/Util/Console/Helper/Table/Renderer/RendererFactory.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/RendererFactory.php
@@ -15,11 +15,20 @@ namespace N98\Util\Console\Helper\Table\Renderer;
 class RendererFactory
 {
     protected static $formats = [
-        'csv'  => 'N98\Util\Console\Helper\Table\Renderer\CsvRenderer',
-        'json' => 'N98\Util\Console\Helper\Table\Renderer\JsonRenderer',
+        'csv'        => 'N98\Util\Console\Helper\Table\Renderer\CsvRenderer',
+        'tsv'        => 'N98\Util\Console\Helper\Table\Renderer\TsvRenderer',
+        'json'       => 'N98\Util\Console\Helper\Table\Renderer\JsonRenderer',
         'json_array' => 'N98\Util\Console\Helper\Table\Renderer\JsonArrayRenderer',
-        'yaml'  => 'N98\Util\Console\Helper\Table\Renderer\YamlRenderer',
-        'xml'  => 'N98\Util\Console\Helper\Table\Renderer\XmlRenderer',
+        'jsonl'      => 'N98\Util\Console\Helper\Table\Renderer\JsonLinesRenderer',
+        'yaml'       => 'N98\Util\Console\Helper\Table\Renderer\YamlRenderer',
+        'markdown'   => 'N98\Util\Console\Helper\Table\Renderer\MarkdownRenderer',
+        'xml'        => 'N98\Util\Console\Helper\Table\Renderer\XmlRenderer',
+    ];
+
+    protected static $aliases = [
+        'yml'    => 'yaml',
+        'md'     => 'markdown',
+        'ndjson' => 'jsonl',
     ];
 
     /**
@@ -34,6 +43,7 @@ class RendererFactory
         }
 
         $format = strtolower($format);
+        $format = self::$aliases[$format] ?? $format;
         if (isset(self::$formats[$format])) {
             $rendererClass = self::$formats[$format];
             return new $rendererClass();

--- a/src/N98/Util/Console/Helper/Table/Renderer/TsvRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/TsvRenderer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+/**
+ * Tab-separated table renderer.
+ */
+class TsvRenderer extends CsvRenderer
+{
+    protected $delimiter = "\t";
+}

--- a/src/N98/Util/Console/Helper/TableHelper.php
+++ b/src/N98/Util/Console/Helper/TableHelper.php
@@ -103,7 +103,17 @@ class TableHelper extends AbstractHelper implements CommandAware
         $rendererFactory = new RendererFactory();
         $renderer = $rendererFactory->create($format);
 
-        if ($renderer && $renderer instanceof RendererInterface) {
+        if ($format !== null && $renderer === false) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unknown output format "%s". Supported formats: %s.',
+                    $format,
+                    implode(', ', RendererFactory::getFormats())
+                )
+            );
+        }
+
+        if ($renderer instanceof RendererInterface) {
             foreach ($rows as &$row) {
                 if (!empty($this->headers)) {
                     $row = array_combine($this->headers, $row);

--- a/tests/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptorTest.php
+++ b/tests/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptorTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Application\Console\Descriptor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MagerunTextDescriptorTest extends TestCase
+{
+    public function testCommandMetadataCannotBreakDecoratedListFormatting(): void
+    {
+        $application = new Application('test');
+        $application->add(new Command('broken-command'));
+        $application->get('broken-command')->setDescription('Broken </muted><accent>command metadata');
+
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+
+        (new MagerunTextDescriptor())->describe($output, $application);
+
+        $this->assertStringContainsString('Broken </muted><accent>command metadata', $output->fetch());
+    }
+}

--- a/tests/N98/Magento/Command/Customer/DeleteCommandTest.php
+++ b/tests/N98/Magento/Command/Customer/DeleteCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\Customer;
+
+use Magento\Store\Model\StoreManagerInterface;
+use N98\Magento\Command\TestCase;
+
+class DeleteCommandTest extends TestCase
+{
+    public function testDeleteByEmail(): void
+    {
+        $email = uniqid('', true) . '@example.com';
+
+        $this->assertDisplayContains([
+            'command'   => 'customer:create',
+            'email'     => $email,
+            'password'  => 'Password123',
+            'firstname' => 'John',
+            'lastname'  => 'Doe',
+            'website'   => $this->getWebsiteCode(),
+        ], 'successfully created');
+
+        $this->assertDisplayContains([
+            'command' => 'customer:delete',
+            '--email' => $email,
+            '--force' => true,
+        ], 'Successfully deleted 1 customer/s');
+    }
+
+    private function getWebsiteCode(): string
+    {
+        $storeManager = $this->getApplication()->getObjectManager()->get(StoreManagerInterface::class);
+
+        return $storeManager->getWebsite('base')->getCode();
+    }
+}

--- a/tests/N98/Util/Console/Helper/Table/Renderer/JsonLinesRendererTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/JsonLinesRendererTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class JsonLinesRendererTest extends TestCase
+{
+    public function testRender(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new JsonLinesRenderer())->render($output, [
+            ['name' => 'Alice', 'active' => true],
+            ['name' => 'Bob', 'active' => false],
+        ]);
+
+        rewind($stream);
+        self::assertSame(
+            "{\"name\":\"Alice\",\"active\":true}\n{\"name\":\"Bob\",\"active\":false}\n",
+            stream_get_contents($stream)
+        );
+        fclose($stream);
+    }
+
+    public function testRenderEmptyRows(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new JsonLinesRenderer())->render($output, []);
+
+        rewind($stream);
+        self::assertSame('', stream_get_contents($stream));
+        fclose($stream);
+    }
+}

--- a/tests/N98/Util/Console/Helper/Table/Renderer/MarkdownRendererTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/MarkdownRendererTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class MarkdownRendererTest extends TestCase
+{
+    public function testRender(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new MarkdownRenderer())->render($output, [
+            ['name' => 'Alice', 'note' => 'A | B'],
+            ['name' => 'Bob', 'note' => "line 1\nline 2"],
+        ]);
+
+        rewind($stream);
+        self::assertSame(
+            "| name | note |\n| --- | --- |\n| Alice | A \\| B |\n| Bob | line 1<br>line 2 |\n",
+            stream_get_contents($stream)
+        );
+        fclose($stream);
+    }
+
+    public function testRenderEmptyRows(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new MarkdownRenderer())->render($output, []);
+
+        rewind($stream);
+        self::assertSame('', stream_get_contents($stream));
+        fclose($stream);
+    }
+}

--- a/tests/N98/Util/Console/Helper/Table/Renderer/RendererFactoryTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/RendererFactoryTest.php
@@ -20,11 +20,33 @@ class RendererFactoryTest extends \PHPUnit\Framework\TestCase
         $csv = $renderFactory->create('csv');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\CsvRenderer', $csv);
 
+        $tsv = $renderFactory->create('tsv');
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\TsvRenderer', $tsv);
+
         $json = $renderFactory->create('json');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\JsonRenderer', $json);
 
         $jsonArray = $renderFactory->create('json_array');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\JsonArrayRenderer', $jsonArray);
+
+        $jsonLines = $renderFactory->create('jsonl');
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\JsonLinesRenderer', $jsonLines);
+
+        $yaml = $renderFactory->create('yaml');
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\YamlRenderer', $yaml);
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\YamlRenderer', $renderFactory->create('yml'));
+
+        $markdown = $renderFactory->create('markdown');
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\MarkdownRenderer', $markdown);
+        $this->assertInstanceOf(
+            'N98\Util\Console\Helper\Table\Renderer\MarkdownRenderer',
+            $renderFactory->create('md')
+        );
+
+        $this->assertInstanceOf(
+            'N98\Util\Console\Helper\Table\Renderer\JsonLinesRenderer',
+            $renderFactory->create('ndjson')
+        );
 
         $xml = $renderFactory->create('xml');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\XmlRenderer', $xml);
@@ -43,8 +65,11 @@ class RendererFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertContains('csv', $formats);
         $this->assertContains('json', $formats);
         $this->assertContains('json_array', $formats);
+        $this->assertContains('tsv', $formats);
+        $this->assertContains('jsonl', $formats);
         $this->assertContains('yaml', $formats);
+        $this->assertContains('markdown', $formats);
         $this->assertContains('xml', $formats);
-        $this->assertCount(5, $formats);
+        $this->assertCount(8, $formats);
     }
 }

--- a/tests/N98/Util/Console/Helper/Table/Renderer/TsvRendererTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/TsvRendererTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class TsvRendererTest extends TestCase
+{
+    public function testRender(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new TsvRenderer())->render($output, [
+            ['col1' => 'val1', 'col2' => 'val2'],
+            ['col1' => 'val3', 'col2' => 'val4'],
+        ]);
+
+        rewind($stream);
+        self::assertSame("col1\tcol2\nval1\tval2\nval3\tval4\n", stream_get_contents($stream));
+        fclose($stream);
+    }
+}

--- a/tests/N98/Util/Console/Helper/TableHelperTest.php
+++ b/tests/N98/Util/Console/Helper/TableHelperTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class TableHelperTest extends TestCase
+{
+    public function testInvalidFormatRaisesAnError(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown output format "invalid"');
+
+        (new TableHelper())->renderByFormat(new BufferedOutput(), [], 'invalid');
+    }
+
+    public function testMissingFormatStillRendersTheDefaultTable(): void
+    {
+        $output = new BufferedOutput();
+        $helper = new TableHelper();
+        $helper->setHeaders(['name']);
+
+        $helper->renderByFormat($output, [['Alice']]);
+
+        self::assertStringContainsString('Alice', $output->fetch());
+    }
+}

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -56,6 +56,13 @@ function cleanup_files_in_magento() {
   assert_output --partial "n98-magerun2"
 }
 
+@test "Test Application - list with ANSI output" {
+  run $BIN --ansi "list"
+  assert_success
+  assert_output --partial "COMMANDS"
+  refute_output --partial "Incorrectly nested style tag found"
+}
+
 @test "Test Application - help" {
   run $BIN "list"
   assert_output --partial "Display help for a command"


### PR DESCRIPTION
## Summary

Make `customer:add-address` interactive when email and website arguments are omitted.

## Changes

- Make the email and website arguments optional.
- Use the shared email prompt and retain website/address prompts.

## Verification

- `php -l src/N98/Magento/Command/Customer/AddAddressCommand.php`
- `git diff --check`
- Verified both positional arguments are no longer required in the command definition.