### PR TITLE
feat(system): add sys:email:test command for deliverability testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ RECENT CHANGES
 
 - Break: raise minimum PHP requirement to 8.2 (and update laminas dependencies accordingly)
 - Add: interactive download command for Magento/Adobe Commerce/Mage-OS
+- Add: `sys:email:test` command to send a test email for deliverability testing
 - Add: prompt interactively for `integration:create` arguments and make `integration:delete` interactive when no name is given
 - Imp: overhaul command output look and feel
 - Fix: stop double-JSON-encoding `admin_user.extra` on `admin:user:change-status`

--- a/config.yaml
+++ b/config.yaml
@@ -167,6 +167,7 @@ commands:
     - N98\Magento\Command\System\Cron\ListCommand
     - N98\Magento\Command\System\Cron\RunCommand
     - N98\Magento\Command\System\Cron\ScheduleCommand
+    - N98\Magento\Command\System\Email\TestCommand
     - N98\Magento\Command\System\InfoCommand
     - N98\Magento\Command\System\MaintenanceCommand
     - N98\Magento\Command\System\Setup\ChangeVersionCommand

--- a/docs/docs/command-docs/system/index.md
+++ b/docs/docs/command-docs/system/index.md
@@ -32,6 +32,9 @@ Commands for system-level information, checks, and maintenance tasks in Magento.
 - [sys:store:config:base-url:list](./sys-store-config-base-url-list.md) - List all configured store URLs
 - [sys:url:list](./sys-url-list.md) - Get all URLs (products, categories, CMS pages)
 
+### Email
+- [sys:email:test](./sys-email-test.md) - Send a test email for deliverability testing
+
 ### System Maintenance
 - [sys:check](./sys-check.md) - Check Magento system for issues
 - [sys:maintenance](./sys-maintenance.md) - Toggle maintenance mode

--- a/docs/docs/command-docs/system/sys-email-test.md
+++ b/docs/docs/command-docs/system/sys-email-test.md
@@ -10,12 +10,14 @@ Sends a minimal test email through Magento's own mail transport, without creatin
 :::
 
 ```sh
-n98-magerun2.phar sys:email:test --to=<email> [--from=<email>] [--cc=<email>]... [--store=<code-or-id>]
+n98-magerun2.phar sys:email:test [--to=<email>] [--from=<email>] [--cc=<email>]... [--store=<code-or-id>]
 ```
+
+If `--to` is omitted, you will be prompted for it interactively.
 
 ## Options
 
-- `--to` (required) - Recipient email address
+- `--to` (required, prompted for interactively if omitted) - Recipient email address
 - `--from` (optional) - Sender email address, defaults to the store's configured general contact email
 - `--cc` (optional, repeatable) - Additional cc email address, can be used multiple times
 - `--store` (optional) - Store code or id, defaults to the current store
@@ -23,6 +25,7 @@ n98-magerun2.phar sys:email:test --to=<email> [--from=<email>] [--cc=<email>]...
 ## Examples
 
 ```sh
+n98-magerun2.phar sys:email:test
 n98-magerun2.phar sys:email:test --to=you@example.com
 n98-magerun2.phar sys:email:test --to=you@example.com --store=2
 n98-magerun2.phar sys:email:test --to=you@example.com --from=sender@example.com --cc=cc1@example.com --cc=cc2@example.com

--- a/docs/docs/command-docs/system/sys-email-test.md
+++ b/docs/docs/command-docs/system/sys-email-test.md
@@ -1,0 +1,29 @@
+---
+title: sys:email:test
+sidebar_label: sys:email:test
+---
+
+# sys:email:test
+
+:::info
+Sends a minimal test email through Magento's own mail transport, without creating any customer accounts or other test data. This is useful for checking email deliverability with tools like mail-tester.com, and for verifying that SMTP settings are correctly configured for a given store view. The email re-uses the "Contact Form" template shipped with Magento, since it does not require any additional data to be set up.
+:::
+
+```sh
+n98-magerun2.phar sys:email:test --to=<email> [--from=<email>] [--cc=<email>]... [--store=<code-or-id>]
+```
+
+## Options
+
+- `--to` (required) - Recipient email address
+- `--from` (optional) - Sender email address, defaults to the store's configured general contact email
+- `--cc` (optional, repeatable) - Additional cc email address, can be used multiple times
+- `--store` (optional) - Store code or id, defaults to the current store
+
+## Examples
+
+```sh
+n98-magerun2.phar sys:email:test --to=you@example.com
+n98-magerun2.phar sys:email:test --to=you@example.com --store=2
+n98-magerun2.phar sys:email:test --to=you@example.com --from=sender@example.com --cc=cc1@example.com --cc=cc2@example.com
+```

--- a/src/N98/Magento/Command/System/Email/TestCommand.php
+++ b/src/N98/Magento/Command/System/Email/TestCommand.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace N98\Magento\Command\System\Email;
 
+use function Laravel\Prompts\text;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -63,7 +64,7 @@ class TestCommand extends AbstractMagentoCommand
     {
         $this
             ->setName('sys:email:test')
-            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Recipient email address')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Recipient email address (prompted for if omitted)')
             ->addOption(
                 'from',
                 null,
@@ -90,8 +91,11 @@ settings are correctly configured for a given store view.
 The email re-uses the "Contact Form" template shipped with Magento, since it does
 not require any additional data to be set up.
 
+If --to is omitted, you will be prompted for it interactively.
+
 Usage:
 
+    n98-magerun2 sys:email:test
     n98-magerun2 sys:email:test --to=you@example.com
     n98-magerun2 sys:email:test --to=you@example.com --store=2
     n98-magerun2 sys:email:test --to=you@example.com --from=sender@example.com --cc=cc1@example.com --cc=cc2@example.com
@@ -106,8 +110,17 @@ HELP
             return Command::FAILURE;
         }
 
-        $to = (string) $input->getOption('to');
-        if ($to === '' || !filter_var($to, FILTER_VALIDATE_EMAIL)) {
+        $to = $input->getOption('to');
+        if ($to === null || $to === '') {
+            $to = text(
+                '<question>Recipient email address:</question>',
+                validate: fn ($value) => $this->validateRequiredEmail($value)
+            );
+        }
+
+        // In non-interactive mode (e.g. missing --to and no TTY), the prompt above cannot ask
+        // and just returns an empty default, so this check still needs to catch that case.
+        if (!is_string($to) || $to === '' || !filter_var($to, FILTER_VALIDATE_EMAIL)) {
             $output->writeln('<error>Please provide a valid recipient email address with --to</error>');
 
             return Command::FAILURE;
@@ -228,5 +241,22 @@ HELP
         }
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @param string $value
+     * @return string|null
+     */
+    private function validateRequiredEmail(string $value): ?string
+    {
+        if ($value === '') {
+            return 'Please enter a recipient email address';
+        }
+
+        if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            return 'Please enter a valid email address';
+        }
+
+        return null;
     }
 }

--- a/src/N98/Magento/Command/System/Email/TestCommand.php
+++ b/src/N98/Magento/Command/System/Email/TestCommand.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Command\System\Email;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Mail\Template\TransportBuilder;
+use Magento\Framework\Translate\Inline\StateInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestCommand extends AbstractMagentoCommand
+{
+    private const DEFAULT_TEMPLATE = 'contact_email_email_template';
+
+    /**
+     * @var TransportBuilder
+     */
+    private $transportBuilder;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var StateInterface
+     */
+    private $inlineTranslation;
+
+    public function inject(
+        TransportBuilder $transportBuilder,
+        StoreManagerInterface $storeManager,
+        ScopeConfigInterface $scopeConfig,
+        StateInterface $inlineTranslation
+    ): void {
+        $this->transportBuilder = $transportBuilder;
+        $this->storeManager = $storeManager;
+        $this->scopeConfig = $scopeConfig;
+        $this->inlineTranslation = $inlineTranslation;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('sys:email:test')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Recipient email address')
+            ->addOption(
+                'from',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Sender email address (defaults to the store\'s general contact email)'
+            )
+            ->addOption(
+                'cc',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Additional cc email address (can be used multiple times)',
+                []
+            )
+            ->addOption('store', null, InputOption::VALUE_REQUIRED, 'Store code or id')
+            ->setDescription('Sends a test email through Magento\'s mail transport for deliverability testing');
+
+        $this->setHelp(
+            <<<HELP
+Sends a minimal test email through Magento's own mail transport, without creating
+any customer accounts or other test data. This is useful for checking email
+deliverability with tools like mail-tester.com, and for verifying that SMTP
+settings are correctly configured for a given store view.
+
+The email re-uses the "Contact Form" template shipped with Magento, since it does
+not require any additional data to be set up.
+
+Usage:
+
+    n98-magerun2 sys:email:test --to=you@example.com
+    n98-magerun2 sys:email:test --to=you@example.com --store=2
+    n98-magerun2 sys:email:test --to=you@example.com --from=sender@example.com --cc=cc1@example.com --cc=cc2@example.com
+HELP
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return Command::FAILURE;
+        }
+
+        $to = (string) $input->getOption('to');
+        if ($to === '' || !filter_var($to, FILTER_VALIDATE_EMAIL)) {
+            $output->writeln('<error>Please provide a valid recipient email address with --to</error>');
+
+            return Command::FAILURE;
+        }
+
+        $from = $input->getOption('from');
+        if ($from !== null && !filter_var($from, FILTER_VALIDATE_EMAIL)) {
+            $output->writeln('<error>The --from email address is not valid</error>');
+
+            return Command::FAILURE;
+        }
+
+        $ccList = (array) $input->getOption('cc');
+        foreach ($ccList as $cc) {
+            if (!filter_var($cc, FILTER_VALIDATE_EMAIL)) {
+                $output->writeln(sprintf('<error>The --cc email address "%s" is not valid</error>', $cc));
+
+                return Command::FAILURE;
+            }
+        }
+
+        try {
+            $store = $this->storeManager->getStore($input->getOption('store'));
+        } catch (NoSuchEntityException $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        if ($from !== null) {
+            $fromEmail = $from;
+            $fromName = 'n98-magerun2';
+        } else {
+            $fromEmail = (string) $this->scopeConfig->getValue(
+                'trans_email/ident_general/email',
+                ScopeInterface::SCOPE_STORE,
+                $store->getCode()
+            );
+            $fromName = (string) $this->scopeConfig->getValue(
+                'trans_email/ident_general/name',
+                ScopeInterface::SCOPE_STORE,
+                $store->getCode()
+            );
+        }
+
+        if ($fromEmail === '') {
+            $output->writeln(
+                '<error>Could not determine a sender email address for this store. Use --from to specify one.</error>'
+            );
+
+            return Command::FAILURE;
+        }
+
+        $templateId = (string) $this->scopeConfig->getValue(
+            'contact/email/email_template',
+            ScopeInterface::SCOPE_STORE,
+            $store->getCode()
+        );
+        if ($templateId === '') {
+            $templateId = self::DEFAULT_TEMPLATE;
+        }
+
+        $variables = [
+            'data' => [
+                'name' => $fromName !== '' ? $fromName : 'n98-magerun2',
+                'email' => $fromEmail,
+                'telephone' => '',
+                'comment' => sprintf(
+                    'This is a test email sent by "n98-magerun2 sys:email:test" on %s for store "%s" (%s) '
+                    . 'to check email deliverability.',
+                    date('Y-m-d H:i:s'),
+                    $store->getName(),
+                    $store->getCode()
+                ),
+            ],
+        ];
+
+        $this->inlineTranslation->suspend();
+        try {
+            $transportBuilder = $this->transportBuilder
+                ->setTemplateIdentifier($templateId)
+                ->setTemplateOptions(
+                    [
+                        'area' => Area::AREA_FRONTEND,
+                        'store' => $store->getId(),
+                    ]
+                )
+                ->setTemplateVars($variables)
+                ->setFromByScope(['email' => $fromEmail, 'name' => $fromName ?: 'n98-magerun2'], $store->getId())
+                ->addTo($to)
+                ->setReplyTo($fromEmail, $fromName !== '' ? $fromName : null);
+
+            foreach ($ccList as $cc) {
+                $transportBuilder->addCc($cc);
+            }
+
+            $transportBuilder->getTransport()->sendMessage();
+        } catch (\Exception $e) {
+            $output->writeln(sprintf('<error>Could not send test email: %s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        } finally {
+            $this->inlineTranslation->resume();
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Test email sent to <comment>%s</comment> from <comment>%s</comment> '
+                . 'for store <comment>%s</comment></info>',
+                $to,
+                $fromEmail,
+                $store->getCode()
+            )
+        );
+
+        if ($ccList !== []) {
+            $output->writeln(sprintf('<info>Cc: <comment>%s</comment></info>', implode(', ', $ccList)));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/N98/Magento/Command/System/Email/TestCommandTest.php
+++ b/tests/N98/Magento/Command/System/Email/TestCommandTest.php
@@ -9,14 +9,22 @@
 namespace N98\Magento\Command\System\Email;
 
 use N98\Magento\Command\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class TestCommandTest extends TestCase
 {
-    public function testMissingToOptionFails()
+    public function testMissingToOptionFailsWithoutPromptingOrSendingMail()
     {
-        $this->assertDisplayContains(
-            ['command' => 'sys:email:test'],
-            'Please provide a valid recipient email address with --to'
+        // Run with interactive=false so the "to" prompt resolves to its empty default instead
+        // of reading from stdin. This guarantees the command fails validation before it ever
+        // reaches the mail transport, regardless of the test runner's stdin/TTY state.
+        $tester = new CommandTester($this->getApplication()->find('sys:email:test'));
+        $status = $tester->execute([], ['interactive' => false]);
+
+        $this->assertSame(1, $status);
+        $this->assertStringContainsString(
+            'Please provide a valid recipient email address with --to',
+            $tester->getDisplay()
         );
     }
 

--- a/tests/N98/Magento/Command/System/Email/TestCommandTest.php
+++ b/tests/N98/Magento/Command/System/Email/TestCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\System\Email;
+
+use N98\Magento\Command\TestCase;
+
+class TestCommandTest extends TestCase
+{
+    public function testMissingToOptionFails()
+    {
+        $this->assertDisplayContains(
+            ['command' => 'sys:email:test'],
+            'Please provide a valid recipient email address with --to'
+        );
+    }
+
+    public function testInvalidToOptionFails()
+    {
+        $this->assertDisplayContains(
+            ['command' => 'sys:email:test', '--to' => 'not-an-email'],
+            'Please provide a valid recipient email address with --to'
+        );
+    }
+
+    public function testInvalidFromOptionFails()
+    {
+        $this->assertDisplayContains(
+            ['command' => 'sys:email:test', '--to' => 'test@example.com', '--from' => 'not-an-email'],
+            'The --from email address is not valid'
+        );
+    }
+
+    public function testInvalidCcOptionFails()
+    {
+        $this->assertDisplayContains(
+            ['command' => 'sys:email:test', '--to' => 'test@example.com', '--cc' => ['not-an-email']],
+            'not-an-email" is not valid'
+        );
+    }
+}

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1050,6 +1050,18 @@ function cleanup_files_in_magento() {
   assert_output --partial "Last executed jobs"
 }
 
+@test "Command: sys:email:test missing --to" {
+  run $BIN "sys:email:test"
+  assert_output --partial "Please provide a valid recipient email address with --to"
+  assert [ "$status" -eq 1 ]
+}
+
+@test "Command: sys:email:test invalid --to" {
+  run $BIN "sys:email:test" --to=not-an-email
+  assert_output --partial "Please provide a valid recipient email address with --to"
+  assert [ "$status" -eq 1 ]
+}
+
 @test "Command: sys:info" {
   run $BIN "sys:info"
   assert_output --partial "Magento System Information"

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1051,13 +1051,15 @@ function cleanup_files_in_magento() {
 }
 
 @test "Command: sys:email:test missing --to" {
-  run $BIN "sys:email:test"
+  # --no-interaction avoids blocking on the interactive prompt and keeps this from ever
+  # reaching the real mail transport.
+  run $BIN "sys:email:test" --no-interaction
   assert_output --partial "Please provide a valid recipient email address with --to"
   assert [ "$status" -eq 1 ]
 }
 
 @test "Command: sys:email:test invalid --to" {
-  run $BIN "sys:email:test" --to=not-an-email
+  run $BIN "sys:email:test" --to=not-an-email --no-interaction
   assert_output --partial "Please provide a valid recipient email address with --to"
   assert [ "$status" -eq 1 ]
 }


### PR DESCRIPTION
Sends a minimal test email through Magento's own mail transport (reusing
the built-in Contact Form template) so deliverability can be checked with
tools like mail-tester.com without creating throwaway customer accounts.
Supports --to, --from, --cc and --store to test per store-view SMTP/sender
configuration.

Closes #2106